### PR TITLE
Avoids explicitly setting ENOMEM

### DIFF
--- a/climb.c
+++ b/climb.c
@@ -29,7 +29,6 @@ Climb Climb_new()
 	Climb ret;
 
 	if (NULL == (ret = malloc(sizeof(struct Climb_)))) {
-		errno = ENOMEM;
 		return NULL;
 	} else {
 		ret->name = NULL;
@@ -150,7 +149,6 @@ void Climb_remove_alias(Climb climb, const char *alias)
 
 	const char **aliases;
 	if (NULL == (aliases = malloc((climb->aliaseslen - 1) * sizeof(const char *)))) {
-		errno = ENOMEM;
 		return;
 	}
 

--- a/grades_font.c
+++ b/grades_font.c
@@ -56,7 +56,6 @@ GradeFontainebleau GradeFontainebleau_new(unsigned int grade, GradeFontainebleau
 	}
 
 	if (NULL == (ret = malloc(sizeof(struct GradeFontainebleau_)))) {
-		errno = ENOMEM;
 		return NULL;
 	}
 

--- a/grades_hueco.c
+++ b/grades_hueco.c
@@ -41,7 +41,6 @@ GradeHueco GradeHueco_new(unsigned int grade, GradeHuecoModifier modifier)
 	}
 
 	if (NULL == (ret = malloc(sizeof(struct GradeHueco_)))) {
-		errno = ENOMEM;
 		return NULL;
 	}
 


### PR DESCRIPTION
Avoids explicitly setting ENOMEM as this is done implicitly through `malloc` and the like.