### PR TITLE
Specifies ranch to run github-pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,7 @@
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
$default-branch is only a workflow templates thing. It cannot be used in workflows themselves.